### PR TITLE
Add a function to control spawning.

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -476,7 +476,7 @@ function mobs:register_mob(name, def)
 end
 
 mobs.spawning_mobs = {}
-function mobs:register_spawn(name, nodes, max_light, min_light, chance, active_object_count, max_height)
+function mobs:register_spawn(name, nodes, max_light, min_light, chance, active_object_count, max_height, spawn_func)
 	mobs.spawning_mobs[name] = true
 	minetest.register_abm({
 		nodenames = nodes,
@@ -508,6 +508,9 @@ function mobs:register_spawn(name, nodes, max_light, min_light, chance, active_o
 			end
 			pos.y = pos.y+1
 			if minetest.env:get_node(pos).name ~= "air" then
+				return
+			end
+			if spawn_func and not spawn_func(pos, node) then
 				return
 			end
 			


### PR DESCRIPTION
I needed more complex conditions for when a mob could spawn than what was there already, so I added an optional callback function that gets called every time they would spawn otherwise.
If the function returns `true`, it will allow the spawn to happen.

**Before:**

``` lua
mobs:register_spawn("garden:worm", {"garden:dirt_with_grass"}, 20, 8, 1, 2, 31000)
```

**After:**

``` lua
mobs:register_spawn("garden:worm", {"garden:dirt_with_grass"}, 20, 8, 1, 2, 31000, function(pos, node)                                                     
     -- Do something here to check if the conditions are right to spawn    
     return true                                                                  
 end)
```
